### PR TITLE
44 defining internal tul as sub repo of quantus opensource and make related adjustments

### DIFF
--- a/quantus/analysis/options.py
+++ b/quantus/analysis/options.py
@@ -63,6 +63,12 @@ def get_analysis_types() -> Tuple[dict, dict]:
     project_root = Path(__file__).parents[4]
     internal_analysis_path = project_root / "Internal-TUL" / "QuantUS-QUS" / "analysis"
     
+    if internal_analysis_path.exists():
+        # Internal modules in QUS depend on quantus.full_workflow from engines/qus/quantus
+        qus_engine_root = project_root / "engines" / "qus"
+        if qus_engine_root.exists() and str(qus_engine_root) not in sys.path:
+            sys.path.append(str(qus_engine_root))
+
     dirs_to_scan = [(current_dir, __package__)]
     if internal_analysis_path.exists():
         if str(internal_analysis_path) not in sys.path:

--- a/quantus/image_loading/utc_loaders/options.py
+++ b/quantus/image_loading/utc_loaders/options.py
@@ -31,6 +31,11 @@ def get_scan_loaders() -> dict:
         if str(internal_tul_path) not in sys.path:
             sys.path.append(str(internal_tul_path))
             
+        # Internal modules in QUS depend on quantus.full_workflow from engines/qus/quantus
+        qus_engine_root = project_root / "engines" / "qus"
+        if qus_engine_root.exists() and str(qus_engine_root) not in sys.path:
+            sys.path.append(str(qus_engine_root))
+            
         for folder in internal_tul_path.iterdir():
             if folder.is_dir() and not folder.name.startswith("_"):
                 try:

--- a/quantus/seg_loading/options.py
+++ b/quantus/seg_loading/options.py
@@ -31,7 +31,7 @@ def get_seg_loaders() -> dict:
         if str(internal_tul_path) not in sys.path:
             sys.path.append(str(internal_tul_path))
             
-        # Internal modules in QUS depend on src.full_workflow from engines/qus/src
+        # Internal modules in QUS depend on quantus.full_workflow from engines/qus/quantus
         qus_engine_root = project_root / "engines" / "qus"
         if qus_engine_root.exists() and str(qus_engine_root) not in sys.path:
             sys.path.append(str(qus_engine_root))

--- a/quantus/seg_loading/options.py
+++ b/quantus/seg_loading/options.py
@@ -40,6 +40,7 @@ def get_seg_loaders() -> dict:
             if item.is_file() and not item.name.startswith("_") and item.suffix == ".py":
                 try:
                     module_name = item.stem
+                    # Use absolute import if sys.path includes the directory
                     module = importlib.import_module(module_name)
                     # For QUS seg loaders, we look for a dict with 'func' and 'exts'
                     # Or we look for functions decorated with @extensions

--- a/quantus/seg_loading/options.py
+++ b/quantus/seg_loading/options.py
@@ -31,6 +31,11 @@ def get_seg_loaders() -> dict:
         if str(internal_tul_path) not in sys.path:
             sys.path.append(str(internal_tul_path))
             
+        # Internal modules in QUS depend on src.full_workflow from engines/qus/src
+        qus_engine_root = project_root / "engines" / "qus"
+        if qus_engine_root.exists() and str(qus_engine_root) not in sys.path:
+            sys.path.append(str(qus_engine_root))
+
         for item in internal_tul_path.iterdir():
             if item.is_file() and not item.name.startswith("_") and item.suffix == ".py":
                 try:


### PR DESCRIPTION
Hi David,

This PR adds the Internal-TUL repository as a git submodule within the engines/ directory to keep all engine components organized together.

looking forward you comments.

Best,
Omid